### PR TITLE
Enable -a flag (all found alignments)

### DIFF
--- a/bwapy/libbwa.py
+++ b/bwapy/libbwa.py
@@ -15,7 +15,7 @@ def get_shared_lib(name):
     """Cross-platform resolution of shared-object libraries, working
     around vagueries of setuptools.
     :param name: name of shared library to find.
-    
+
     :returns: FFI shared library object.
     """
     try:
@@ -70,7 +70,7 @@ ffi.cdef("""
     int n_cigar;     // number of CIGAR operations
     uint32_t *cigar; // CIGAR in the BAM encoding: opLen<<4|op; op to integer mapping: MIDSH=>01234
     char *XA;        // alternative mappings
-  
+
     int score, sub, alt_sc;
   } mem_aln_t;
 
@@ -132,7 +132,7 @@ ffi.cdef("""
     uint8_t  *mem;
   } bwaidx_t;
 
-  bwaidx_t *bwa_idx_load_all(const char *hint); 
+  bwaidx_t *bwa_idx_load_all(const char *hint);
   void bwa_idx_destroy(bwaidx_t *idx);
 
   /////////////////
@@ -146,9 +146,9 @@ ffi.cdef("""
     int pen_clip5,pen_clip3;// clipping penalty. This score is not deducted from the DP score.
     int w;                  // band width
     int zdrop;              // Z-dropoff
-    
+
     uint64_t max_mem_intv;
-    
+
     int T;                  // output score threshold; only affecting output
     int flag;               // see MEM_F_* macros
     int min_seed_len;       // minimum seed length
@@ -280,4 +280,4 @@ def main():
         print('Found {} alignments for input {}.'.format(len(alignments), i))
         for aln in alignments:
             print('  ', aln)
- 
+

--- a/bwapy/memopts.c
+++ b/bwapy/memopts.c
@@ -10,7 +10,7 @@
 
 
 // The options that we parse, some options removed (mostly paired end things)
-const char valid_opts[] = "MYjk:c:v:s:r:A:B:O:E:U:w:L:d:T:Q:D:m:N:W:x:G:h:y:X:";
+const char valid_opts[] = "aMYjk:c:v:s:r:A:B:O:E:U:w:L:d:T:Q:D:m:N:W:x:G:h:y:X:";
 
 static void update_a(mem_opt_t *opt, const mem_opt_t *opt0)
 {
@@ -54,6 +54,7 @@ mem_opt_t * get_opts(int argc, char *argv[], bwaidx_t * idx)
 		else if (c == 'B') opt->b = atoi(optarg), opt0.b = 1;
 		else if (c == 'T') opt->T = atoi(optarg), opt0.T = 1;
 		else if (c == 'U') opt->pen_unpaired = atoi(optarg), opt0.pen_unpaired = 1;
+		else if (c == 'a') opt->flag |= MEM_F_ALL;
 		else if (c == 'M') opt->flag |= MEM_F_NO_MULTI;
 		else if (c == 'Y') opt->flag |= MEM_F_SOFTCLIP;
 		else if (c == 'c') opt->max_occ = atoi(optarg), opt0.max_occ = 1;


### PR DESCRIPTION
I need this personally and I think this is within scope as `-a` is targeted for single-end reads:

https://github.com/lh3/bwa/blob/08764215c6615ea52894e1ce9cd10d2a2faa37a6/bwa.1#L300-L302

Compiles and works fine on my machine, namely putting 'a' in options results in multiple alignments and only one is reported when `a` flag is not present.

